### PR TITLE
Rename release_notes.md to notes.md

### DIFF
--- a/core/releases.js
+++ b/core/releases.js
@@ -9,5 +9,5 @@ module.exports = {
   RELEASES_DIRECTORY_PATH: ".publisher/releases",
 
   RELEASE_MANIFEST_FILENAME: "release.toml",
-  RELEASE_NOTES_FILENAME: "release_notes.md",
+  RELEASE_NOTES_FILENAME: "notes.md",
 };


### PR DESCRIPTION
When viewing changed files of a pull request on GitHub, files are sorted alphabetically.

I had initially believed having the versioning TOML file first would be best, but have reversed my opinion.

In the case of large monorepos, I think this ordering is a source of friction, as reviewers have scroll through dozens of unchanged packages to get to the release notes file.

**Before:**
1. Versions of changed packages (`release.toml`)
2. Versions of *un*changed packages (`release.toml`) *__← Noise__*
3. Release notes for changed packages (`release_notes.md`)

By renaming `release_notes.md` to `notes.md` the ordering is switched to be:

**Improved:**
1. Release notes for changed packages (`notes.md`)
2. Versions of changed packages (`release.toml`)
3. Versions of *un*changed packages (`release.toml`) *__← Noise__*

This way, the long list of unchanged packages is at the bottom and doesn't have to be scrolled through. during reviews.

I also think it is helpful when reviewing version changes to see the changelog first.