### PR TITLE
Only publish changed packages in canary releases

### DIFF
--- a/core/deployments.js
+++ b/core/deployments.js
@@ -4,23 +4,31 @@
 /*::
 type CanaryPayload = {
   id: number,
+  unchangedPackages: {
+    [string]: {
+      version: string,
+    }
+  }
 };
 */
 
 const CanaryDeployment = {
   taskId: "publish:canary",
 
-  serializePayload({ id } /*: CanaryPayload */) {
+  serializePayload({ id, unchangedPackages } /*: CanaryPayload */) {
     const payload = {
-      schema_version: 1,
+      schema_version: 2,
       id,
+      unchangedPackages,
     };
     return payload;
   },
   deserializePayload(deploymentPayload /*: Payload */) {
     const payload /*: any */ = deploymentPayload;
     if (payload.schema_version === 1) {
-      return { id: payload.id };
+      return { id: payload.id, unchangedPackages: {} };
+    } else if (payload.schema_version === 2) {
+      return { id: payload.id, unchangedPackages: payload.unchangedPackages };
     }
     throw new Error("Invalid payload schema version");
   },

--- a/deployment-handler/index.js
+++ b/deployment-handler/index.js
@@ -49,7 +49,7 @@ async function deploymentHandler(
     previews: ["ant-man-preview", "flash-preview", "shadow-cat-preview"],
   });
 
-  const { deployment, repository } = eventPayload;
+  const { deployment } = eventPayload;
 
   if (deployment.task === CanaryDeployment.taskId) {
     await publishCanary(github, eventPayload);
@@ -128,8 +128,6 @@ async function publishStable(github, payload) {
 
 async function publishDeployment(github, payload, getPackages) {
   const { deployment, repository } = payload;
-
-  const started_at = new Date().toISOString();
 
   await github.repos.createDeploymentStatus({
     owner: repository.owner.login,

--- a/push-handler/index.js
+++ b/push-handler/index.js
@@ -53,8 +53,6 @@ async function validateRelease(github, payload) {
   const { id: check_run_id } = check.data;
 
   try {
-    // const workspaces = await getWorkspaces();
-
     // TODO: validate
 
     await github.checks.update({

--- a/push-handler/index.js
+++ b/push-handler/index.js
@@ -1,18 +1,9 @@
 // @flow
 "use strict";
 
-const cp = require("child_process");
-const { promisify } = require("util");
 const path = require("path");
-const fs = require("fs");
-const execFile = promisify(cp.execFile);
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
 
 const Octokit = require("@octokit/rest");
-
-const TOML = require("@iarna/toml");
-const semver = require("semver");
 
 const RELEASE_VALIDATION_CHECK_NAME = "Release validation";
 
@@ -62,7 +53,7 @@ async function validateRelease(github, payload) {
   const { id: check_run_id } = check.data;
 
   try {
-    const workspaces = await getWorkspaces();
+    // const workspaces = await getWorkspaces();
 
     // TODO: validate
 

--- a/rush-helpers/index.js
+++ b/rush-helpers/index.js
@@ -1,7 +1,6 @@
 // @flow
 "use strict";
 
-const cp = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { promisify } = require("util");


### PR DESCRIPTION
By adding prior versions for unchanged packages into the deployment payload, we can skip publishing of unchanged packages in canary releases.

This means fewer packages to publish as well as fewer dependencies to update for consumers.