### PR TITLE
Add release via commit comments

### DIFF
--- a/canary-cli/index.js
+++ b/canary-cli/index.js
@@ -1,0 +1,65 @@
+const token = process.env.GH_TOKEN;
+
+if (!token) {
+  console.error("GH_TOKEN is required");
+  process.exit(1);
+}
+
+const [, , repo_slug, sha] = process.argv;
+
+if (!repo_slug || !sha) {
+  console.error(`Usage: canary.js [repo_slug] [git_sha]`);
+  process.exit(1);
+}
+
+const [owner, repo] = repo_slug.split("/");
+
+const Octokit = require("@octokit/rest");
+const { canaryPublish } = require("@publisher/probot-app");
+const readline = require("readline");
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+rl.question(
+  `Publishing canary release for repo: ${owner}/${repo} at commit: ${sha}
+Continue? [y/n] `,
+  answer => {
+    rl.close();
+    if (answer === "y") {
+      localCanaryPublish({ token, owner, repo, sha })
+        .then(() => {
+          console.log("Success");
+        })
+        .catch(err => {
+          console.error(err);
+          process.exit(1);
+        });
+    } else {
+      console.log("Aborting.");
+    }
+  },
+);
+
+async function localCanaryPublish({ token, owner, repo, sha }) {
+  const github = new Octokit({
+    auth: token,
+  });
+
+  const mockContext /*: any */ = {
+    github,
+    repo: opts => ({ ...opts, owner, repo }),
+    payload: {
+      check_run: {
+        check_suite: {
+          head_branch: null,
+        },
+        head_sha: sha,
+      },
+    },
+  };
+  const checkRunContext /*: Context<Webhooks$WebhookPayloadCheckRun> */ = mockContext;
+  await canaryPublish(checkRunContext);
+}

--- a/canary-cli/package.json
+++ b/canary-cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@publisher/canary-cli",
+  "version": "0.0.0-monorepo",
+  "main": "index.js",
+  "dependencies": {
+    "@publisher/probot-app": "0.0.0-monorepo"
+  },
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "workspaces": [
+    "canary-cli",
     "core",
     "deployment-handler",
     "probot-app",

--- a/probot-app/index.js
+++ b/probot-app/index.js
@@ -44,6 +44,8 @@ module.exports = (app /*: Application */) => {
   app.on("commit_comment", onCommitComment);
 };
 
+module.exports.canaryPublish = canaryPublish;
+
 async function onDeploymentStatus(context) {
   const { deployment_status, deployment } = context.payload;
 

--- a/probot-app/index.js
+++ b/probot-app/index.js
@@ -98,8 +98,8 @@ async function onCommitComment(context) {
   }
 
   const command = {
-    "!canary": "CANARY",
-    "!release": "RELEASE",
+    "!canary": CANARY_PUBLISH_ACTION_ID,
+    "!release": RELEASE_PR_ACTION_ID,
   }[body.replace(/\r\n|\r|\n/g, "").trim()];
 
   if (!command) {
@@ -119,9 +119,9 @@ async function onCommitComment(context) {
     },
   };
   const checkRunContext /*: Context<Webhooks$WebhookPayloadCheckRun> */ = fullContext;
-  if (command === "CANARY") {
+  if (command === CANARY_PUBLISH_ACTION_ID) {
     canaryPublish(checkRunContext);
-  } else if (command === "RELEASE") {
+  } else if (command === RELEASE_PR_ACTION_ID) {
     releasePR(checkRunContext);
   }
 }


### PR DESCRIPTION
There's GitHub regression where GitHub checks aren't displayed in the UI anymore, so buttons are no longer visible.

This PR adds a workaround to allow for triggering releases via commit comments `!canary` and `!release`.